### PR TITLE
Add a "new revision" parameter to digital signature action

### DIFF
--- a/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/constants/PDFToolkitConstants.java
+++ b/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/constants/PDFToolkitConstants.java
@@ -43,7 +43,8 @@ public abstract class PDFToolkitConstants
     public static final String PARAM_KEY_TYPE          				= "key-type";
     public static final String PARAM_ALIAS              			= "alias";
     public static final String PARAM_STORE_PASSWORD     			= "store-password";
-    
+    public static final String PARAM_NEW_REVISION    				= "new-revision";
+
     public static final String PARAM_SPLIT_FREQUENCY    			= "split-frequency";
     
     public static final String PARAM_WATERMARK_IMAGE    			= "watermark-image";

--- a/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/repo/action/executer/PDFSignatureActionExecuter.java
+++ b/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/repo/action/executer/PDFSignatureActionExecuter.java
@@ -86,6 +86,7 @@ public class PDFSignatureActionExecuter extends BasePDFStampActionExecuter
         paramList.add(new ParameterDefinitionImpl(PDFToolkitConstants.PARAM_ALIAS, DataTypeDefinition.TEXT, true, getParamDisplayLabel(PDFToolkitConstants.PARAM_ALIAS)));
         paramList.add(new ParameterDefinitionImpl(PDFToolkitConstants.PARAM_STORE_PASSWORD, DataTypeDefinition.TEXT, true, getParamDisplayLabel(PDFToolkitConstants.PARAM_STORE_PASSWORD)));
         paramList.add(new ParameterDefinitionImpl(PDFToolkitConstants.PARAM_DESTINATION_NAME, DataTypeDefinition.TEXT, false, getParamDisplayLabel(PDFToolkitConstants.PARAM_DESTINATION_NAME)));
+        paramList.add(new ParameterDefinitionImpl(PDFToolkitConstants.PARAM_NEW_REVISION, DataTypeDefinition.BOOLEAN, false, getParamDisplayLabel(PDFToolkitConstants.PARAM_NEW_REVISION), false));
 
         super.addParameterDefinitions(paramList);
 

--- a/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/service/PDFToolkitServiceImpl.java
+++ b/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/service/PDFToolkitServiceImpl.java
@@ -411,7 +411,14 @@ public class PDFToolkitServiceImpl extends PDFToolkitConstants implements PDFToo
 		int height = getInteger(params.get(PARAM_HEIGHT));
 		int width = getInteger(params.get(PARAM_WIDTH));
 		int pageNumber = getInteger(params.get(PARAM_PAGE));
-
+		
+		// By default, append the signature as a new PDF revision to avoid
+		// invalidating any signatures that might already exist on the doc
+		boolean appendToExisting = true;
+		if (params.get(PARAM_NEW_REVISION) != null) {
+			appendToExisting = Boolean.valueOf(String.valueOf(params.get(PARAM_NEW_REVISION)));
+		}
+		
 		// New keystore parameters
 		String alias = (String)params.get(PARAM_ALIAS);
 		String storePassword = (String)params.get(PARAM_STORE_PASSWORD);
@@ -464,7 +471,15 @@ public class PDFToolkitServiceImpl extends PDFToolkitConstants implements PDFToo
 			File file = new File(tempDir, ffs.getFileInfo(targetNodeRef).getName());
 
 			FileOutputStream fout = new FileOutputStream(file);
-			PdfStamper stamp = PdfStamper.createSignature(reader, fout, '\0');
+			
+			// When adding a second signature, append must be called on PdfStamper.createSignature
+			// to avoid invalidating previous signatures
+			PdfStamper stamp = null;
+			if (appendToExisting) {
+				stamp = PdfStamper.createSignature(reader, fout, '\0', tempDir, true);
+			} else {
+				stamp = PdfStamper.createSignature(reader, fout, '\0');
+			}
 			PdfSignatureAppearance sap = stamp.getSignatureAppearance();
 			sap.setCrypto(key, chain, null, PdfSignatureAppearance.WINCER_SIGNED);
 


### PR DESCRIPTION
Add a new parameter that controls whether or not a new revision should be created when adding a digital signature. A new revision prevents existing signatures from being invalidated when an additional signature is added. With this change, by default, a new revision will always be used. Pass false to use the old behavior.