### PR TITLE
Add page number checks including ability to specify negative number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ solr/solr_home
 *.log.*
 *.log
 
+pdf-toolkit-repo/bin

--- a/pdf-toolkit-repo/pom.xml
+++ b/pdf-toolkit-repo/pom.xml
@@ -33,7 +33,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.alfresco</groupId>
-			<artifactId>alfresco-enterprise-repository</artifactId>
+			<artifactId>alfresco-repository</artifactId>
 			<version>${alfresco.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/service/PDFToolkitServiceImpl.java
+++ b/pdf-toolkit-repo/src/main/java/org/alfresco/extension/pdftoolkit/service/PDFToolkitServiceImpl.java
@@ -464,6 +464,25 @@ public class PDFToolkitServiceImpl extends PDFToolkitConstants implements PDFToo
 			ContentReader pdfReader = getReader(targetNodeRef);
 			PdfReader reader = new PdfReader(pdfReader.getContentInputStream());
 
+			// If the page number is 0 because it couldn't be parsed or for
+			// some other reason, set it to the first page, which is 1.
+			// If the page number is negative, assume the intent is to "wrap".
+			// For example, -1 would always be the last page.
+			int numPages = reader.getNumberOfPages();
+			if (pageNumber < 1 && pageNumber == 0) {
+				pageNumber = 1; // use the first page
+			} else {
+				// page number is negative
+				pageNumber = numPages + 1 + pageNumber;
+				if (pageNumber <= 0) pageNumber = 1;
+			}
+			
+			// if the page number specified is more than the num of pages,
+			// use the last page
+			if (pageNumber > numPages) {
+				pageNumber = numPages;
+			}
+			
 			// create temp dir to store file
 			File alfTempDir = TempFileProvider.getTempDir();
 			tempDir = new File(alfTempDir.getPath() + File.separatorChar + targetNodeRef.getId());
@@ -486,7 +505,7 @@ public class PDFToolkitServiceImpl extends PDFToolkitConstants implements PDFToo
 			// set reason for signature and location of signer
 			sap.setReason(reason);
 			sap.setLocation(location);
-
+	
 			if (visibility.equalsIgnoreCase(VISIBILITY_VISIBLE))
 			{
 				//create the signature rectangle using either the provided position or

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
             | NOTE: Please Refer to Alfresco Support for access to Enterprise artifacts -->
         <alfresco.groupId>org.alfresco</alfresco.groupId>
         <!-- Defines the Alfresco version to work against. Allowed values are: org.alfresco | org.alfresco.enterprise -->
-        <alfresco.version>5.0.2</alfresco.version>
+        <alfresco.version>5.0.d</alfresco.version>
         <!-- This control the root logging level for all apps -->
         <app.log.root.level>WARN</app.log.root.level>
         <!-- This controls the default data location for dir.root -->


### PR DESCRIPTION
If the page number is incorrectly parsed it is set to 0 which means the digital signature overlay will not get added. Further, it is possible to specify a page number greater than the number of pages in the PDF.

This commit adds checks to guard against those conditions. It also makes it possible to specify a negative number for the page number which means the signature will be applied to the page counting backward instead of forward. This allows you to specify -1 as the page number, for example, and the signature will always be applied to the last page in the PDF.